### PR TITLE
Fix falsy "enabled" flag being ignored

### DIFF
--- a/lib/mnemosyne/railtie.rb
+++ b/lib/mnemosyne/railtie.rb
@@ -8,8 +8,10 @@ module Mnemosyne
 
       config['application'] ||= app.class.name.underscore.titleize
 
-      config['logger']  ||= Rails.logger
-      config['enabled'] ||= config.key?('server')
+      config['logger'] ||= Rails.logger
+
+      # If a server URL is configured, we assume that Mnemosyne should be enabled
+      config['enabled'] = config.key?('server') unless config.key?('enabled')
 
       config = ::Mnemosyne::Config.new(config)
 


### PR DESCRIPTION
Because of using the `||=` operator, falsy values for `enabled` were
being ignored and overwritten when the `server` flag existed.

For mnemosyne.yml files like the following:

    common: &common
      server: amqp://localhost

    development:
      <<: *common
      enabled: false

...this meant that the `enabled: false` was being ignored for the
development environment.